### PR TITLE
Preemptible support in Open Targets Platform

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,6 +106,7 @@ module "backend_api" {
   vm_api_image                  = var.config_vm_api_image
   vm_api_image_project          = var.config_vm_api_image_project
   vm_api_boot_disk_size         = var.config_vm_api_boot_disk_size
+  vm_flag_preemptible           = var.config_vm_api_flag_preemptible
   backend_connection_map = zipmap(
     var.config_deployment_regions,
     [

--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,7 @@ module "backend_elastic_search" {
   vm_elastic_search_image          = var.config_vm_elastic_search_image
   vm_elastic_search_image_project  = var.config_vm_elastic_search_image_project
   vm_elastic_search_boot_disk_size = var.config_vm_elastic_search_boot_disk_size
+  vm_flag_preemptible              = var.config_vm_elasticsearch_flag_preemptible
   // Additional firewall tags if development mode is 'ON'
   vm_firewall_tags       = local.dev_mode_fw_tags
   deployment_region      = var.config_deployment_regions[count.index]
@@ -70,6 +71,7 @@ module "backend_clickhouse" {
   vm_clickhouse_image          = var.config_vm_clickhouse_image
   vm_clickhouse_image_project  = var.config_vm_clickhouse_image_project
   vm_clickhouse_boot_disk_size = var.config_vm_clickhouse_boot_disk_size
+  vm_flag_preemptible          = var.config_vm_clickhouse_flag_preemptible
   // Additional firewall tags if development mode is 'ON'
   vm_firewall_tags       = local.dev_mode_fw_tags
   deployment_region      = var.config_deployment_regions[count.index]
@@ -170,5 +172,6 @@ module "web_app" {
   webserver_vm_image             = var.config_webapp_webserver_vm_image
   webserver_vm_image_project     = var.config_webapp_webserver_vm_image_project
   webserver_vm_boot_disk_size    = var.config_webapp_webserver_vm_boot_disk_size
+  vm_flag_preemptible            = var.config_vm_webserver_flag_preemptible
   deployment_target_size         = 1
 }

--- a/main.tf
+++ b/main.tf
@@ -23,10 +23,10 @@ resource "google_compute_project_default_network_tier" "default_network_tier" {
 
 // --- Elastic Search Backend --- //
 module "backend_elastic_search" {
-  source = "./modules/elasticsearch"
+  source     = "./modules/elasticsearch"
   project_id = var.config_project_id
-  
-  count  = length(var.config_deployment_regions)
+
+  count = length(var.config_deployment_regions)
 
   depends_on               = [module.vpc_network]
   module_wide_prefix_scope = "${var.config_release_name}-es-${count.index}"
@@ -52,10 +52,10 @@ module "backend_elastic_search" {
 
 // --- Clickhouse Backend --- //
 module "backend_clickhouse" {
-  source = "./modules/clickhouse"
+  source     = "./modules/clickhouse"
   project_id = var.config_project_id
 
-  count  = length(var.config_deployment_regions)
+  count = length(var.config_deployment_regions)
 
   depends_on               = [module.vpc_network]
   module_wide_prefix_scope = "${var.config_release_name}-ch-${count.index}"

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -67,7 +67,7 @@ resource "google_compute_instance_template" "otpapi_template" {
     automatic_restart = !var.vm_flag_preemptible
     on_host_maintenance = "TERMINATE"
     preemptible = var.vm_flag_preemptible
-    provisioning_model = "SPOT"
+    //provisioning_model = "SPOT"
   }
 
   disk {

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -64,7 +64,7 @@ resource "google_compute_instance_template" "otpapi_template" {
   can_ip_forward = false
 
   scheduling {
-    automatic_restart = true
+    automatic_restart = !var.vm_flag_preemptible
     on_host_maintenance = "MIGRATE"
     preemptible = var.vm_flag_preemptible
   }

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -65,8 +65,9 @@ resource "google_compute_instance_template" "otpapi_template" {
 
   scheduling {
     automatic_restart = !var.vm_flag_preemptible
-    on_host_maintenance = "MIGRATE"
+    on_host_maintenance = "TERMINATE"
     preemptible = var.vm_flag_preemptible
+    provisioning_model = "SPOT"
   }
 
   disk {

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -66,6 +66,7 @@ resource "google_compute_instance_template" "otpapi_template" {
   scheduling {
     automatic_restart = true
     on_host_maintenance = "MIGRATE"
+    preemptible = var.vm_flag_preemptible
   }
 
   disk {

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -65,7 +65,7 @@ resource "google_compute_instance_template" "otpapi_template" {
 
   scheduling {
     automatic_restart = !var.vm_flag_preemptible
-    on_host_maintenance = "TERMINATE"
+    on_host_maintenance = var.vm_flag_preemptible ? "TERMINATE" : "MIGRATION"
     preemptible = var.vm_flag_preemptible
     //provisioning_model = "SPOT"
   }

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -19,6 +19,7 @@ resource "random_string" "random" {
     otpapi_template_source_image = local.otpapi_template_source_image,
     vm_platform_api_image_version = var.vm_platform_api_image_version,
     vm_startup_script = md5(file("${path.module}/scripts/instance_startup.sh"))
+    vm_flag_preemptible = var.vm_flag_preemptible
   }
 }
 

--- a/modules/api/variables.tf
+++ b/modules/api/variables.tf
@@ -96,6 +96,12 @@ variable "vm_api_boot_disk_size" {
   default = "10GB"
 }
 
+variable "vm_flag_preemptible" {
+  description = "Use this flag to tell the module to use a preemptible instance, default: 'false'"
+  type = bool
+  default = false
+}
+
 variable "deployment_target_size" {
   description = "Initial API node count per region"
   type = number

--- a/modules/clickhouse/main.tf
+++ b/modules/clickhouse/main.tf
@@ -59,7 +59,7 @@ resource "google_compute_instance_template" "clickhouse_template" {
 
   scheduling {
     automatic_restart = !var.vm_flag_preemptible
-    on_host_maintenance = "TERMINATE"
+    on_host_maintenance = var.vm_flag_preemptible ? "TERMINATE" : "MIGRATION"
     preemptible = var.vm_flag_preemptible
     //provisioning_model = "SPOT"
   }

--- a/modules/clickhouse/main.tf
+++ b/modules/clickhouse/main.tf
@@ -18,6 +18,7 @@ resource "random_string" "random" {
     clickhouse_template_machine_type = local.clickhouse_template_machine_type,
     clickhouse_template_source_image = local.clickhouse_template_source_image,
     vm_startup_script = md5(file("${path.module}/scripts/instance_startup.sh"))
+    vm_flag_preemptible = var.vm_flag_preemptible
   }
 }
 

--- a/modules/clickhouse/main.tf
+++ b/modules/clickhouse/main.tf
@@ -58,8 +58,10 @@ resource "google_compute_instance_template" "clickhouse_template" {
   can_ip_forward = false
 
   scheduling {
-    automatic_restart = true
-    on_host_maintenance = "MIGRATE"
+    automatic_restart = !var.vm_flag_preemptible
+    on_host_maintenance = "TERMINATE"
+    preemptible = var.vm_flag_preemptible
+    //provisioning_model = "SPOT"
   }
 
   disk {

--- a/modules/clickhouse/variables.tf
+++ b/modules/clickhouse/variables.tf
@@ -83,6 +83,12 @@ variable "vm_clickhouse_boot_disk_size" {
   default = "250GB"
 }
 
+variable "vm_flag_preemptible" {
+  description = "Use this flag to tell the module to use a preemptible instance, default: 'false'"
+  type = bool
+  default = false
+}
+
 variable "deployment_target_size" {
   description = "This number configures how many instances should be running, default '1'"
   type = number

--- a/modules/elasticsearch/main.tf
+++ b/modules/elasticsearch/main.tf
@@ -19,6 +19,7 @@ resource "random_string" "random" {
     elastic_search_template_tags = join("", sort(local.elastic_search_template_tags)),
     vm_elastic_search_version = var.vm_elastic_search_version,
     vm_startup_script = md5(file("${path.module}/scripts/instance_startup.sh"))
+    vm_flag_preemptible = var.vm_flag_preemptible
   }
 }
 

--- a/modules/elasticsearch/main.tf
+++ b/modules/elasticsearch/main.tf
@@ -59,8 +59,10 @@ resource "google_compute_instance_template" "elastic_search_template" {
   can_ip_forward = false
 
   scheduling {
-    automatic_restart = true
-    on_host_maintenance = "MIGRATE"
+    automatic_restart = !var.vm_flag_preemptible
+    on_host_maintenance = var.vm_flag_preemptible ? "TERMINATE" : "MIGRATION"
+    preemptible = var.vm_flag_preemptible
+    //provisioning_model = "SPOT"
   }
 
   disk {

--- a/modules/elasticsearch/variables.tf
+++ b/modules/elasticsearch/variables.tf
@@ -91,3 +91,10 @@ variable "vm_elastic_search_boot_disk_size" {
   type = string
   default = "500GB"
 }
+
+variable "vm_flag_preemptible" {
+  description = "Use this flag to tell the module to use a preemptible instance, default: 'false'"
+  type = bool
+  default = false
+}
+

--- a/modules/webapp/variables.tf
+++ b/modules/webapp/variables.tf
@@ -191,6 +191,12 @@ variable "webserver_vm_boot_disk_size" {
   default = "10GB"
 }
 
+variable "vm_flag_preemptible" {
+  description = "Use this flag to tell the module to use a preemptible instance, default: 'false'"
+  type = bool
+  default = false
+}
+
 variable "deployment_target_size" {
   description = "Initial Web Server instance count per region"
   type = number

--- a/modules/webapp/webservers-compute.tf
+++ b/modules/webapp/webservers-compute.tf
@@ -56,8 +56,10 @@ resource "google_compute_instance_template" "webserver_template" {
   can_ip_forward = false
 
   scheduling {
-    automatic_restart = true
-    on_host_maintenance = "MIGRATE"
+    automatic_restart = !var.vm_flag_preemptible
+    on_host_maintenance = var.vm_flag_preemptible ? "TERMINATE" : "MIGRATION"
+    preemptible = var.vm_flag_preemptible
+    //provisioning_model = "SPOT"
   }
 
   disk {

--- a/modules/webapp/webservers-compute.tf
+++ b/modules/webapp/webservers-compute.tf
@@ -10,6 +10,7 @@ resource "random_string" "random_web_server_suffix" {
     deployment_bundle_url = local.webapp_deployment_bundle_url
     nginx_docker_image_version = var.webserver_docker_image_version
     startup_script = md5(file("${path.module}/scripts/webserver_vm_startup_script.sh"))
+    vm_flag_preemptible = var.vm_flag_preemptible
   }
 }
 

--- a/networking-glb.tf
+++ b/networking-glb.tf
@@ -64,7 +64,7 @@ module "glb_platform" {
 
   // Dependencies
   depends_on = [
-    module.vpc_network/*,
+    module.vpc_network /*,
     module.web_app,
     module.backend_api*/
   ]

--- a/profiles/deployment_context.dev_platform
+++ b/profiles/deployment_context.dev_platform
@@ -1,0 +1,68 @@
+// --- Sample deployment ---//
+// --- Release information --- //
+config_release_name = "devpf"
+// --- Deployment configuration --- //
+config_gcp_default_region = "europe-west4"
+config_gcp_default_zone   = "europe-west4-b"
+config_project_id         = "open-targets-eu-dev"
+config_deployment_regions = ["europe-west1"]
+// --- Elastic Search configuration --- //
+config_vm_elastic_search_image_project  = "open-targets-eu-dev"
+config_vm_elastic_search_vcpus          = "6"
+config_vm_elastic_search_mem            = "39936"
+config_vm_elastic_search_image          = "platform22-02-4-220225-020046-es"
+config_vm_elastic_search_version        = "7.10.2"
+config_vm_elastic_search_boot_disk_size = "500GB"
+// --- Clickhouse configuration --- //
+config_vm_clickhouse_vcpus          = "4"
+config_vm_clickhouse_mem            = "26624"
+config_vm_clickhouse_image          = "platform22-02-4-220225-020046-ch"
+config_vm_clickhouse_image_project  = "open-targets-eu-dev"
+config_vm_clickhouse_boot_disk_size = "250GB"
+// --- API configuration --- //
+config_vm_platform_api_image_version = "22.02.2"
+config_vm_api_vcpus                  = "2"
+config_vm_api_mem                    = "7680"
+config_vm_api_image                  = "cos-stable"
+config_vm_api_image_project          = "cos-cloud"
+config_vm_api_boot_disk_size         = "10GB"
+config_vm_api_flag_preemptible       = true
+// --- DNS --- //
+config_dns_project_id             = "open-targets-eu-dev"
+config_dns_subdomain_prefix       = "dev"
+config_dns_managed_zone_name      = "opentargets-xyz"
+config_dns_managed_zone_dns_name  = "opentargets.xyz."
+config_dns_platform_api_subdomain = "api"
+// --- Web App configuration --- //
+config_webapp_repo_name = "opentargets/platform-app"
+config_webapp_release   = "22.02.2"
+config_webapp_deployment_context_map = {
+  DEVOPS_CONTEXT_PLATFORM_APP_CONFIG_URL_API      = "'https://api.platform.dev.opentargets.xyz/api/v4/graphql'"
+  DEVOPS_CONTEXT_PLATFORM_APP_CONFIG_URL_API_BETA = "'https://api.platform.dev.opentargets.xyz/api/v4/graphql'"
+  DEVOPS_CONTEXT_PLATFORM_APP_CONFIG_EFO_URL      = "'/data/ontology/efo_json/diseases_efo.jsonl'"
+}
+// Robots.txt profile --- //
+config_webapp_robots_profile = "default"
+// Web Application Customisation Profile --- //
+// config_webapp_custom_profile = "default.js"
+// Data Context --- //
+config_webapp_bucket_name_data_assets = "open-targets-pre-data-releases"
+config_webapp_data_context_release    = "22.02.4"
+// Sitemaps generation --- //
+config_webapp_sitemaps_repo_name        = "opentargets/ot-sitemap-cli"
+config_webapp_sitemaps_release          = "1.1.0"
+config_webapp_sitemaps_bigquery_table   = "platform_dev"
+config_webapp_sitemaps_bigquery_project = "open-targets-eu-dev"
+// Web App Web Servers configuration --- //
+config_webapp_webserver_docker_image_version = "1.21.3"
+// --- GLB Configuration --- //
+config_glb_webapp_enable_cdn = false
+// --- Security Configuration --- //
+// Allow Access only from Specified CIDR
+// config_security_restrict_source_ips = []
+// Enable / Disable network security policies application
+// config_security_api_enable    = true
+// config_security_webapp_enable = true
+// --- Development Mode --- //
+config_set_dev_mode_on = true
+//config_enable_inspection                    = true

--- a/profiles/deployment_context.dev_platform
+++ b/profiles/deployment_context.dev_platform
@@ -7,18 +7,20 @@ config_gcp_default_zone   = "europe-west4-b"
 config_project_id         = "open-targets-eu-dev"
 config_deployment_regions = ["europe-west1"]
 // --- Elastic Search configuration --- //
-config_vm_elastic_search_image_project  = "open-targets-eu-dev"
-config_vm_elastic_search_vcpus          = "6"
-config_vm_elastic_search_mem            = "39936"
-config_vm_elastic_search_image          = "platform22-02-4-220225-020046-es"
-config_vm_elastic_search_version        = "7.10.2"
-config_vm_elastic_search_boot_disk_size = "500GB"
+config_vm_elastic_search_image_project   = "open-targets-eu-dev"
+config_vm_elastic_search_vcpus           = "6"
+config_vm_elastic_search_mem             = "39936"
+config_vm_elastic_search_image           = "platform22-02-4-220225-020046-es"
+config_vm_elastic_search_version         = "7.10.2"
+config_vm_elastic_search_boot_disk_size  = "500GB"
+config_vm_elasticsearch_flag_preemptible = true
 // --- Clickhouse configuration --- //
-config_vm_clickhouse_vcpus          = "4"
-config_vm_clickhouse_mem            = "26624"
-config_vm_clickhouse_image          = "platform22-02-4-220225-020046-ch"
-config_vm_clickhouse_image_project  = "open-targets-eu-dev"
-config_vm_clickhouse_boot_disk_size = "250GB"
+config_vm_clickhouse_vcpus            = "4"
+config_vm_clickhouse_mem              = "26624"
+config_vm_clickhouse_image            = "platform22-02-4-220225-020046-ch"
+config_vm_clickhouse_image_project    = "open-targets-eu-dev"
+config_vm_clickhouse_boot_disk_size   = "250GB"
+config_vm_clickhouse_flag_preemptible = true
 // --- API configuration --- //
 config_vm_platform_api_image_version = "22.02.2"
 config_vm_api_vcpus                  = "2"
@@ -55,6 +57,7 @@ config_webapp_sitemaps_bigquery_table   = "platform_dev"
 config_webapp_sitemaps_bigquery_project = "open-targets-eu-dev"
 // Web App Web Servers configuration --- //
 config_webapp_webserver_docker_image_version = "1.21.3"
+config_vm_webserver_flag_preemptible         = true
 // --- GLB Configuration --- //
 config_glb_webapp_enable_cdn = false
 // --- Security Configuration --- //

--- a/profiles/tfenv.dev-platform
+++ b/profiles/tfenv.dev-platform
@@ -1,0 +1,3 @@
+# This is a template Terraform Environment Configuration for creating new profiles
+TF_VAR_config_tf_backend_bucket_name='opentargets-eu-dev-terraform'
+TF_VAR_config_tf_backend_prefix='dev_platform'

--- a/variables.tf
+++ b/variables.tf
@@ -121,6 +121,12 @@ variable "config_vm_api_boot_disk_size" {
   type        = string
 }
 
+variable "config_vm_api_flag_preemptible" {
+  description = "Use this flag for deploying API nodes on preemptible VMs, default 'false'"
+  type        = bool
+  default     = false
+}
+
 // --- DNS Configuration --- //
 variable "config_dns_project_id" {
   description = "Project ID to use when making changes to Cloud DNS service"
@@ -185,8 +191,8 @@ variable "config_webapp_robots_profile" {
 
 variable "config_webapp_custom_profile" {
   description = "Web application customisation profile to use, if not provided, the default set by the web app module will be used"
-  type = string
-  default = "default.js"
+  type        = string
+  default     = "default.js"
 }
 
 variable "config_webapp_bucket_name_data_assets" {

--- a/variables.tf
+++ b/variables.tf
@@ -69,6 +69,12 @@ variable "config_vm_elastic_search_boot_disk_size" {
   type        = string
 }
 
+variable "config_vm_elasticsearch_flag_preemptible" {
+  description = "Use this flag for deploying Elastic Search nodes on preemptible VMs, default 'false'"
+  type        = bool
+  default     = false
+}
+
 // --- Clickhouse configuration --- //
 variable "config_vm_clickhouse_vcpus" {
   description = "CPU count for Clickhouse instances"
@@ -88,6 +94,12 @@ variable "config_vm_clickhouse_image" {
 variable "config_vm_clickhouse_image_project" {
   description = "Project where to find the instance image to use"
   type        = string
+}
+
+variable "config_vm_clickhouse_flag_preemptible" {
+  description = "Use this flag for deploying Clickhouse nodes on preemptible VMs, default 'false'"
+  type        = bool
+  default     = false
 }
 
 variable "config_vm_clickhouse_boot_disk_size" {
@@ -260,6 +272,13 @@ variable "config_webapp_webserver_vm_boot_disk_size" {
   type        = string
   default     = "10GB"
 }
+
+variable "config_vm_webserver_flag_preemptible" {
+  description = "Use this flag for deploying Web nodes on preemptible VMs, default 'false'"
+  type        = bool
+  default     = false
+}
+
 
 // --- Global Load Balancer --- //
 variable "config_glb_webapp_enable_cdn" {


### PR DESCRIPTION
This pull requests extends Open Targets Platform provisioner for supporting preemptible VMs.
It also includes a permanent development deployment context with preemptible flags active.
Context for this pull request: opentargets/platform#1980 