### PR TITLE
Layered context for deployment definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tfbackend.tf
 deployment_context.tfvars
 **/.DS_Store
 tfbackend.tf.bak
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ deployment_context.tfvars
 **/.DS_Store
 tfbackend.tf.bak
 .idea
+# Ignore the active deployment context profile
+deployment_context.auto.tfvars

--- a/01-defaults-gcp.auto.tfvars
+++ b/01-defaults-gcp.auto.tfvars
@@ -1,0 +1,5 @@
+// --- Google Cloud Platform Layer --- //
+// Defaults --- //
+config_gcp_default_region = "europe-west4"
+config_gcp_default_zone   = "europe-west4-b"
+config_project_id         = "open-targets-eu-dev"

--- a/01-defaults-gcp.auto.tfvars
+++ b/01-defaults-gcp.auto.tfvars
@@ -1,4 +1,7 @@
 // --- Google Cloud Platform Layer --- //
+
+// This configuration file is used to configure the Google Cloud Platform (GCP) base layer of the Open Targets Platform.
+
 // Defaults --- //
 config_gcp_default_region = "europe-west4"
 config_gcp_default_zone   = "europe-west4-b"

--- a/10-vm_geometry-api.auto.tfvars
+++ b/10-vm_geometry-api.auto.tfvars
@@ -1,0 +1,5 @@
+// --- Machine Geometry Layer --- //
+// API Node --- //
+config_vm_api_vcpus          = "2"
+config_vm_api_mem            = "7680"
+config_vm_api_boot_disk_size = "10GB"

--- a/10-vm_geometry-api.auto.tfvars
+++ b/10-vm_geometry-api.auto.tfvars
@@ -1,4 +1,7 @@
 // --- Machine Geometry Layer --- //
+
+// This is the layer that defines the machine geometry.
+
 // API Node --- //
 config_vm_api_vcpus          = "2"
 config_vm_api_mem            = "7680"

--- a/10-vm_geometry-clickhouse.auto.tfvars
+++ b/10-vm_geometry-clickhouse.auto.tfvars
@@ -1,0 +1,5 @@
+// --- Machine Geometry Layer --- //
+// Cickhouse --- //
+config_vm_clickhouse_vcpus          = "4"
+config_vm_clickhouse_mem            = "26624"
+config_vm_clickhouse_boot_disk_size = "250GB"

--- a/10-vm_geometry-clickhouse.auto.tfvars
+++ b/10-vm_geometry-clickhouse.auto.tfvars
@@ -1,4 +1,7 @@
 // --- Machine Geometry Layer --- //
+
+// This is the layer that defines the machine geometry.
+
 // Cickhouse --- //
 config_vm_clickhouse_vcpus          = "4"
 config_vm_clickhouse_mem            = "26624"

--- a/10-vm_geometry-elastic_search.auto.tfvars
+++ b/10-vm_geometry-elastic_search.auto.tfvars
@@ -1,0 +1,5 @@
+// --- Machine Geometry Layer --- //
+// Elastic Search --- //
+config_vm_elastic_search_vcpus          = "6"
+config_vm_elastic_search_mem            = "39936"
+config_vm_elastic_search_boot_disk_size = "500GB"

--- a/10-vm_geometry-elastic_search.auto.tfvars
+++ b/10-vm_geometry-elastic_search.auto.tfvars
@@ -1,4 +1,7 @@
 // --- Machine Geometry Layer --- //
+
+// This is the layer that defines the machine geometry.
+
 // Elastic Search --- //
 config_vm_elastic_search_vcpus          = "6"
 config_vm_elastic_search_mem            = "39936"

--- a/10-vm_geometry-web_server.auto.tfvars
+++ b/10-vm_geometry-web_server.auto.tfvars
@@ -1,0 +1,2 @@
+// --- Machine Geometry Layer --- //
+// Web Server node --- //

--- a/10-vm_geometry-web_server.auto.tfvars
+++ b/10-vm_geometry-web_server.auto.tfvars
@@ -1,2 +1,6 @@
 // --- Machine Geometry Layer --- //
+
+// This is the layer that defines the machine geometry.
+
 // Web Server node --- //
+// Using defaults for all parameters

--- a/11-vm_persona-api.auto.tfvars
+++ b/11-vm_persona-api.auto.tfvars
@@ -1,3 +1,6 @@
 // --- Machine Persona Layer --- //
+
+// This layer defines the machine persona for the VM, e.g. provisioning method, maybe labels, etc.
+
 // API node --- //
 config_vm_api_flag_preemptible = false

--- a/11-vm_persona-api.auto.tfvars
+++ b/11-vm_persona-api.auto.tfvars
@@ -3,4 +3,5 @@
 // This layer defines the machine persona for the VM, e.g. provisioning method, maybe labels, etc.
 
 // API node --- //
-config_vm_api_flag_preemptible = false
+// By default, we use the development configuration, where the provisioning model for VMs is preemptible.
+config_vm_api_flag_preemptible = true

--- a/11-vm_persona-api.auto.tfvars
+++ b/11-vm_persona-api.auto.tfvars
@@ -1,0 +1,3 @@
+// --- Machine Persona Layer --- //
+// API node --- //
+config_vm_api_flag_preemptible = false

--- a/11-vm_persona-clickhouse.auto.tfvars
+++ b/11-vm_persona-clickhouse.auto.tfvars
@@ -1,0 +1,3 @@
+// --- Machine Persona Layer --- //
+// Clickhouse node --- //
+config_vm_clickhouse_flag_preemptible = false

--- a/11-vm_persona-clickhouse.auto.tfvars
+++ b/11-vm_persona-clickhouse.auto.tfvars
@@ -3,4 +3,5 @@
 // This layer defines the machine persona for the VM, e.g. provisioning method, maybe labels, etc.
 
 // Clickhouse node --- //
-config_vm_clickhouse_flag_preemptible = false
+// By default, we use the development configuration, where the provisioning model for VMs is preemptible.
+config_vm_clickhouse_flag_preemptible = true

--- a/11-vm_persona-clickhouse.auto.tfvars
+++ b/11-vm_persona-clickhouse.auto.tfvars
@@ -1,3 +1,6 @@
 // --- Machine Persona Layer --- //
+
+// This layer defines the machine persona for the VM, e.g. provisioning method, maybe labels, etc.
+
 // Clickhouse node --- //
 config_vm_clickhouse_flag_preemptible = false

--- a/11-vm_persona-elastic_search.auto.tfvars
+++ b/11-vm_persona-elastic_search.auto.tfvars
@@ -3,4 +3,5 @@
 // This layer defines the machine persona for the VM, e.g. provisioning method, maybe labels, etc.
 
 // Elastic Search node --- //
-config_vm_elasticsearch_flag_preemptible = false
+// By default, we use the development configuration, where the provisioning model for VMs is preemptible.
+config_vm_elasticsearch_flag_preemptible = true

--- a/11-vm_persona-elastic_search.auto.tfvars
+++ b/11-vm_persona-elastic_search.auto.tfvars
@@ -1,3 +1,6 @@
 // --- Machine Persona Layer --- //
+
+// This layer defines the machine persona for the VM, e.g. provisioning method, maybe labels, etc.
+
 // Elastic Search node --- //
 config_vm_elasticsearch_flag_preemptible = false

--- a/11-vm_persona-elastic_search.auto.tfvars
+++ b/11-vm_persona-elastic_search.auto.tfvars
@@ -1,0 +1,3 @@
+// --- Machine Persona Layer --- //
+// Elastic Search node --- //
+config_vm_elasticsearch_flag_preemptible = false

--- a/11-vm_persona-web_server.auto.tfvars
+++ b/11-vm_persona-web_server.auto.tfvars
@@ -1,3 +1,6 @@
 // --- Machine Persona Layer --- //
+
+// This layer defines the machine persona for the VM, e.g. provisioning method, maybe labels, etc.
+
 // Web Server node --- //
 config_vm_webserver_flag_preemptible = true

--- a/11-vm_persona-web_server.auto.tfvars
+++ b/11-vm_persona-web_server.auto.tfvars
@@ -1,0 +1,3 @@
+// --- Machine Persona Layer --- //
+// Web Server node --- //
+config_vm_webserver_flag_preemptible = true

--- a/11-vm_persona-web_server.auto.tfvars
+++ b/11-vm_persona-web_server.auto.tfvars
@@ -3,4 +3,5 @@
 // This layer defines the machine persona for the VM, e.g. provisioning method, maybe labels, etc.
 
 // Web Server node --- //
+// By default, we use the development configuration, where the provisioning model for VMs is preemptible.
 config_vm_webserver_flag_preemptible = true

--- a/20-vm_os-api.auto.tfvars
+++ b/20-vm_os-api.auto.tfvars
@@ -1,4 +1,7 @@
 // --- Machine OS Layer --- //
+
+// This layer defines the OS (standard) image to use for the VMs, at GCP level, if using a custom made machine image in a particular project, that will not be reflected here.
+
 // API node --- //
 config_vm_api_image         = "cos-stable"
 config_vm_api_image_project = "cos-cloud"

--- a/20-vm_os-api.auto.tfvars
+++ b/20-vm_os-api.auto.tfvars
@@ -1,0 +1,4 @@
+// --- Machine OS Layer --- //
+// API node --- //
+config_vm_api_image         = "cos-stable"
+config_vm_api_image_project = "cos-cloud"

--- a/20-vm_os-clickhouse.auto.tfvars
+++ b/20-vm_os-clickhouse.auto.tfvars
@@ -1,0 +1,3 @@
+// --- Machine OS Layer --- //
+// Clickhouse node --- //
+config_vm_clickhouse_image_project = "open-targets-eu-dev"

--- a/20-vm_os-clickhouse.auto.tfvars
+++ b/20-vm_os-clickhouse.auto.tfvars
@@ -1,3 +1,6 @@
 // --- Machine OS Layer --- //
+
+// This layer defines the OS (standard) image to use for the VMs, at GCP level, if using a custom made machine image in a particular project, that will not be reflected here.
+
 // Clickhouse node --- //
 config_vm_clickhouse_image_project = "open-targets-eu-dev"

--- a/20-vm_os-elastic_search.auto.tfvars
+++ b/20-vm_os-elastic_search.auto.tfvars
@@ -1,0 +1,3 @@
+// --- Machine OS Layer --- //
+// Elastic Search node --- //
+config_vm_elastic_search_image_project = "open-targets-eu-dev"

--- a/20-vm_os-elastic_search.auto.tfvars
+++ b/20-vm_os-elastic_search.auto.tfvars
@@ -1,3 +1,6 @@
 // --- Machine OS Layer --- //
+
+// This layer defines the OS (standard) image to use for the VMs, at GCP level, if using a custom made machine image in a particular project, that will not be reflected here.
+
 // Elastic Search node --- //
 config_vm_elastic_search_image_project = "open-targets-eu-dev"

--- a/20-vm_os-web_server.auto.tfvars
+++ b/20-vm_os-web_server.auto.tfvars
@@ -1,2 +1,6 @@
 // --- Machine OS Layer --- //
+
+// This layer defines the OS (standard) image to use for the VMs, at GCP level, if using a custom made machine image in a particular project, that will not be reflected here.
+
 // Web Server node --- //
+// Using defaults for all settings

--- a/20-vm_os-web_server.auto.tfvars
+++ b/20-vm_os-web_server.auto.tfvars
@@ -1,0 +1,2 @@
+// --- Machine OS Layer --- //
+// Web Server node --- //

--- a/30-vm_sw-api.auto.tfvars
+++ b/30-vm_sw-api.auto.tfvars
@@ -1,2 +1,6 @@
 // --- Machine Software Layer --- //
+
+// This file defines the software we lay on top of the OS, under the layers that will complete the machine definition.
+
 // API node --- //
+// Using default values for the API nodes

--- a/30-vm_sw-api.auto.tfvars
+++ b/30-vm_sw-api.auto.tfvars
@@ -1,0 +1,2 @@
+// --- Machine Software Layer --- //
+// API node --- //

--- a/30-vm_sw-clickhouse.auto.tfvars
+++ b/30-vm_sw-clickhouse.auto.tfvars
@@ -1,0 +1,2 @@
+// --- Machine Software Layer --- //
+// Clickhouse node --- //

--- a/30-vm_sw-clickhouse.auto.tfvars
+++ b/30-vm_sw-clickhouse.auto.tfvars
@@ -1,2 +1,6 @@
 // --- Machine Software Layer --- //
+
+// This file defines the software we lay on top of the OS, under the layers that will complete the machine definition.
+
 // Clickhouse node --- //
+// TODO - Move Clickhouse to this layer when we get rid of the custom installation image.

--- a/30-vm_sw-elastic_search.auto.tfvars
+++ b/30-vm_sw-elastic_search.auto.tfvars
@@ -1,0 +1,3 @@
+// --- Machine Software Layer --- //
+// Elastic Search node --- //
+config_vm_elastic_search_version = "7.10.2"

--- a/30-vm_sw-elastic_search.auto.tfvars
+++ b/30-vm_sw-elastic_search.auto.tfvars
@@ -1,3 +1,7 @@
 // --- Machine Software Layer --- //
+
+// This file defines the software we lay on top of the OS, under the layers that will complete the machine definition.
+
 // Elastic Search node --- //
+// This is the Elastic Search Docker image we will use for the Elastic Search node.
 config_vm_elastic_search_version = "7.10.2"

--- a/30-vm_sw-web_server.auto.tfvars
+++ b/30-vm_sw-web_server.auto.tfvars
@@ -1,4 +1,9 @@
 // --- Machine Software Layer --- //
+
+// This file defines the software we lay on top of the OS, under the layers that will complete the machine definition.
+
 // Web Server node --- //
-config_webapp_repo_name                      = "opentargets/ot-ui-apps"
+// Repository where the provisioner will look for the web application bundle
+config_webapp_repo_name = "opentargets/ot-ui-apps"
+// This is the nginx image version that will be used to serve the web application
 config_webapp_webserver_docker_image_version = "1.21.3"

--- a/30-vm_sw-web_server.auto.tfvars
+++ b/30-vm_sw-web_server.auto.tfvars
@@ -1,0 +1,4 @@
+// --- Machine Software Layer --- //
+// Web Server node --- //
+config_webapp_repo_name                      = "opentargets/ot-ui-apps"
+config_webapp_webserver_docker_image_version = "1.21.3"

--- a/50-security.auto.tfvars
+++ b/50-security.auto.tfvars
@@ -1,4 +1,8 @@
 // --- Security Layer --- //
-// By default, API and Web access control is disabled --- //
+
+// This layer defines deployment-wide security settings.
+
+// By default, API and Web security policies are disabled --- //
+// By default, we use the development configuration, where security is disabled
 config_security_api_enable    = false
 config_security_webapp_enable = false

--- a/50-security.auto.tfvars
+++ b/50-security.auto.tfvars
@@ -1,0 +1,4 @@
+// --- Security Layer --- //
+// By default, API and Web access control is disabled --- //
+config_security_api_enable    = false
+config_security_webapp_enable = false

--- a/60-dns.auto.tfvars
+++ b/60-dns.auto.tfvars
@@ -1,5 +1,8 @@
 // --- DNS Layer --- //
-// Default DNS configuration matches Development Environment --- //
+
+// This file lays out the DNS configuration for the deployment.
+
+// By default, we use the development DNS configuration
 config_dns_project_id             = "open-targets-eu-dev"
 config_dns_subdomain_prefix       = "dev"
 config_dns_managed_zone_name      = "opentargets-xyz"

--- a/60-dns.auto.tfvars
+++ b/60-dns.auto.tfvars
@@ -1,0 +1,7 @@
+// --- DNS Layer --- //
+// Default DNS configuration matches Development Environment --- //
+config_dns_project_id             = "open-targets-eu-dev"
+config_dns_subdomain_prefix       = "dev"
+config_dns_managed_zone_name      = "opentargets-xyz"
+config_dns_managed_zone_dns_name  = "opentargets.xyz."
+config_dns_platform_api_subdomain = "api"

--- a/70-glb.auto.tfvars
+++ b/70-glb.auto.tfvars
@@ -1,0 +1,3 @@
+// --- Global Load Balancer Layer --- //
+// Default configuration matches Development Environment --- //
+config_glb_webapp_enable_cdn = false

--- a/70-glb.auto.tfvars
+++ b/70-glb.auto.tfvars
@@ -1,3 +1,6 @@
 // --- Global Load Balancer Layer --- //
-// Default configuration matches Development Environment --- //
+
+// This file is used to configure the global load balancer layer.
+
+// By default, we use the development configuration
 config_glb_webapp_enable_cdn = false

--- a/80-defaults-sitemaps.auto.tfvars
+++ b/80-defaults-sitemaps.auto.tfvars
@@ -1,5 +1,8 @@
 // --- Application Layer --- //
-// Sitemaps default configuration, it matches Development Environment --- //
+
+// Default configuration for sitemaps generation is the Development Environment
+
+// Sitemaps default configuration, it matches Development Environment
 config_webapp_sitemaps_repo_name        = "opentargets/ot-sitemap-cli"
 config_webapp_sitemaps_release          = "1.1.0"
 config_webapp_sitemaps_bigquery_table   = "platform_dev"

--- a/80-defaults-sitemaps.auto.tfvars
+++ b/80-defaults-sitemaps.auto.tfvars
@@ -1,0 +1,6 @@
+// --- Application Layer --- //
+// Sitemaps default configuration, it matches Development Environment --- //
+config_webapp_sitemaps_repo_name        = "opentargets/ot-sitemap-cli"
+config_webapp_sitemaps_release          = "1.1.0"
+config_webapp_sitemaps_bigquery_table   = "platform_dev"
+config_webapp_sitemaps_bigquery_project = "open-targets-eu-dev"

--- a/81-defaults-webapp.auto.tfvars
+++ b/81-defaults-webapp.auto.tfvars
@@ -1,5 +1,6 @@
 // --- Application Layer --- //
-// Web application default configuration, it matches the Development Environment --- //
+
+// Default configuration for the web application is the Development Environment
 config_webapp_deployment_context_map = {
   DEVOPS_CONTEXT_PLATFORM_APP_CONFIG_URL_API      = "'https://api.platform.dev.opentargets.xyz/api/v4/graphql'"
   DEVOPS_CONTEXT_PLATFORM_APP_CONFIG_URL_API_BETA = "'https://api.platform.dev.opentargets.xyz/api/v4/graphql'"
@@ -8,4 +9,5 @@ config_webapp_deployment_context_map = {
 // Robots.txt profile --- //
 config_webapp_robots_profile = "default"
 // Web Application Customisation Profile --- //
+// Using the default profile
 // config_webapp_custom_profile = "default.js"

--- a/81-defaults-webapp.auto.tfvars
+++ b/81-defaults-webapp.auto.tfvars
@@ -1,0 +1,11 @@
+// --- Application Layer --- //
+// Web application default configuration, it matches the Development Environment --- //
+config_webapp_deployment_context_map = {
+  DEVOPS_CONTEXT_PLATFORM_APP_CONFIG_URL_API      = "'https://api.platform.dev.opentargets.xyz/api/v4/graphql'"
+  DEVOPS_CONTEXT_PLATFORM_APP_CONFIG_URL_API_BETA = "'https://api.platform.dev.opentargets.xyz/api/v4/graphql'"
+  DEVOPS_CONTEXT_PLATFORM_APP_CONFIG_EFO_URL      = "'/data/ontology/efo_json/diseases_efo.jsonl'"
+}
+// Robots.txt profile --- //
+config_webapp_robots_profile = "default"
+// Web Application Customisation Profile --- //
+// config_webapp_custom_profile = "default.js"

--- a/90-monitoring.auto.tfvars
+++ b/90-monitoring.auto.tfvars
@@ -1,0 +1,13 @@
+// --- Monitoring layer --- //
+
+// This file defines the baseline configuration for the monitoring layer on the deployed infrastructure
+
+// Development facilities //
+
+// Development mode will enable the following features:
+// - SSH access to deployed instances
+config_set_dev_mode_on = true
+
+// Inspection will enable the following features:
+// - An SSH enabled instance within the same VPC as the deployed instances, for every deployed region
+//config_enable_inspection                    = true

--- a/locals.tf
+++ b/locals.tf
@@ -48,11 +48,11 @@ locals {
   glb_netsec_effective_policy_webapp = local.netsec_enable_policies_webapp ? google_compute_security_policy.netsec_policy_webapp[0].self_link : null
 
   //---  Network Security --- //
-  netsec_restriction_source_ip_cidrs = toset(regexall("[[:digit:]]{1,3}\\.[[:digit:]]{1,3}\\.[[:digit:]]{1,3}\\.[[:digit:]]{1,3}/[[:digit:]]{1,2}", trimspace(file("${path.module}/profiles/${var.config_security_restrict_source_ips_cidrs_file}"))))
+  netsec_restriction_source_ip_cidrs                 = toset(regexall("[[:digit:]]{1,3}\\.[[:digit:]]{1,3}\\.[[:digit:]]{1,3}\\.[[:digit:]]{1,3}/[[:digit:]]{1,2}", trimspace(file("${path.module}/profiles/${var.config_security_restrict_source_ips_cidrs_file}"))))
   netsec_restriction_source_ip_cidrs_policy_listings = chunklist(local.netsec_restriction_source_ip_cidrs, 10)
-  netsec_enable_policies_api           = var.config_security_api_enable && (length(local.netsec_restriction_source_ip_cidrs) > 0)
-  netsec_enable_policies_webapp        = var.config_security_webapp_enable && (length(local.netsec_restriction_source_ip_cidrs) > 0)
-  
+  netsec_enable_policies_api                         = var.config_security_api_enable && (length(local.netsec_restriction_source_ip_cidrs) > 0)
+  netsec_enable_policies_webapp                      = var.config_security_webapp_enable && (length(local.netsec_restriction_source_ip_cidrs) > 0)
+
 
   // --- Debugging --- // 
   canaryvm_zone = "${var.config_deployment_regions[0]}-b"

--- a/networking-security.tf
+++ b/networking-security.tf
@@ -24,7 +24,7 @@ resource "google_compute_security_policy" "netsec_policy_api" {
     content {
       description = "Allow API traffic from the given list of CIDRs, group #${rule.key}"
       action      = "allow"
-      priority    = "${rule.key + 1000}"
+      priority    = rule.key + 1000
       match {
         versioned_expr = "SRC_IPS_V1"
         config {
@@ -76,9 +76,9 @@ resource "google_compute_security_policy" "netsec_policy_webapp" {
   dynamic "rule" {
     for_each = local.netsec_enable_policies_webapp ? local.netsec_restriction_source_ip_cidrs_policy_listings : []
     content {
-      description   = "Allow WEB traffic from the given list of CIDRs, group #${rule.key}"
+      description = "Allow WEB traffic from the given list of CIDRs, group #${rule.key}"
       action      = "allow"
-      priority = "${rule.key + 1000}"
+      priority    = rule.key + 1000
       match {
         versioned_expr = "SRC_IPS_V1"
         config {

--- a/profiles/deployment_context.2302
+++ b/profiles/deployment_context.2302
@@ -1,76 +1,54 @@
-// --- Sample deployment ---//
-// --- Release information --- //
-config_release_name                         = "production"
-// --- Deployment configuration --- //
-config_gcp_default_region                   = "europe-west4"
-config_gcp_default_zone                     = "europe-west4-b"
-config_project_id                           = "open-targets-platform"
+// --- PRODUCTION Open Targets Platform ---//
+
+// --- Release Specific Information (THIS IS THE MAIN PLACE WHERE THINGS CHANGE BETWEEN PRODUCTION RELEASES) --- //
+// Regions
 config_deployment_regions                   = [ "europe-west1" ]
-// --- Elastic Search configuration --- //
-config_vm_elastic_search_image_project      = "open-targets-eu-dev"
-config_vm_elastic_search_vcpus              = "6"
-config_vm_elastic_search_mem                = "39936"
+// Elastic Search configuration
 config_vm_elastic_search_image              = "mbdevplatform-230214-031922-es"
-config_vm_elastic_search_version            = "7.10.2"
-config_vm_elastic_search_boot_disk_size     = "500GB"
-// --- Clickhouse configuration --- //
-config_vm_clickhouse_vcpus                  = "4"
-config_vm_clickhouse_mem                    = "26624"
+// Clickhouse configuration
 config_vm_clickhouse_image                  = "mbdevplatform-230214-031922-ch"
-config_vm_clickhouse_image_project          = "open-targets-eu-dev"
-config_vm_clickhouse_boot_disk_size         = "250GB"
-// --- API configuration --- //
+// API configuration
 config_vm_platform_api_image_version        = "dev23.02.7"
-config_vm_api_vcpus                         = "2"
-config_vm_api_mem                           = "7680"
-config_vm_api_image                         = "cos-stable"
-config_vm_api_image_project                 = "cos-cloud"
-config_vm_api_boot_disk_size                = "10GB"
 config_vm_version_major                     = "23"
 config_vm_version_minor                     = "02"
 config_vm_version_patch                     = "7"
 config_vm_data_year                         = "23"
 config_vm_data_month                        = "02"
 config_vm_data_iteration                    = "0"
-// --- DNS --- 2/
+// Web App configuration
+config_webapp_release                       = "v0.3.4"
+// Web App Data Context
+config_webapp_bucket_name_data_assets       = "open-targets-data-releases"
+config_webapp_data_context_release          = "23.02"
+// -[END]- Release Specific Information --- //
+
+
+
+// --- This section is common to all production releases, unless custom changes need to be made --- //
+// Deployment configuration
+config_release_name                         = "production"
+config_project_id                           = "open-targets-platform"
+// DNS
 config_dns_project_id                       = "open-targets-prod"
 config_dns_subdomain_prefix                 = null
 config_dns_managed_zone_name                = "opentargets-org"
 config_dns_managed_zone_dns_name            = "opentargets.org."
 config_dns_platform_api_subdomain           = "api"
-// --- Web App configuration --- //
-config_webapp_repo_name                     = "opentargets/ot-ui-apps"
-config_webapp_release                       = "v0.3.4"
+// Web App configuration
 config_webapp_deployment_context_map        = {
     DEVOPS_CONTEXT_PLATFORM_APP_CONFIG_URL_API = "'https://api.platform.opentargets.org/api/v4/graphql'"
     DEVOPS_CONTEXT_PLATFORM_APP_CONFIG_URL_API_BETA = "'https://api.platform.opentargets.org/api/v4/graphql'"
     DEVOPS_CONTEXT_PLATFORM_APP_CONFIG_EFO_URL = "'/data/ontology/efo_json/diseases_efo.jsonl'"
     DEVOPS_CONTEXT_PLATFORM_APP_CONFIG_GOOGLE_TAG_MANAGER_ID = "'GTM-WPXWRDV'"
-    // DEVOPS_CONTEXT_PLATFORM_APP_CONFIG_PRIMARY_COLOR = "''"
-    // DEVOPS_CONTEXT_PLATFORM_APP_CONFIG_FLAG_SHOW_OTAR_PROJECTS = "''"
 }
-// Robots.txt profile --- //
+// Robots.txt profile
 config_webapp_robots_profile                = "production"
-// Web Application Customisation Profile --- //
-// config_webapp_custom_profile = "default.js"
-// Data Context --- //
-config_webapp_bucket_name_data_assets       = "open-targets-data-releases"
-config_webapp_data_context_release          = "23.02"
-// Sitemaps generation --- //
-config_webapp_sitemaps_repo_name            = "opentargets/ot-sitemap-cli"
-config_webapp_sitemaps_release              = "1.1.0"
+// Sitemaps generation
 config_webapp_sitemaps_bigquery_table       = "platform"
 config_webapp_sitemaps_bigquery_project     = "open-targets-prod"
-// Web App Web Servers configuration --- //
-config_webapp_webserver_docker_image_version= "1.21.3"
-// --- GLB Configuration --- //
-// config_glb_webapp_enable_cdn = false
-// --- Security Configuration --- //
-// Allow Access only from Specified CIDR
-// config_security_restrict_source_ips = []
-// Enable / Disable network security policies application
-// config_security_api_enable    = true
-// config_security_webapp_enable = true
-// --- Development Mode --- //
-config_set_dev_mode_on                      = true
-//config_enable_inspection                    = true
+// Machines' Persona configuration
+// For Production, we use 'on-demand' provisioning model
+config_vm_api_flag_preemptible = false
+config_vm_clickhouse_flag_preemptible = false
+config_vm_elasticsearch_flag_preemptible = false
+config_vm_webserver_flag_preemptible = false

--- a/profiles/deployment_context.dev_platform
+++ b/profiles/deployment_context.dev_platform
@@ -1,77 +1,27 @@
 // --- Open Targets Platform PERMANENT development deployment ---//
 // --- Release information --- //
 config_release_name = "devpf"
+
 // --- Deployment configuration --- //
-config_gcp_default_region = "europe-west4"
-config_gcp_default_zone   = "europe-west4-b"
-config_project_id         = "open-targets-eu-dev"
 config_deployment_regions = ["europe-west1"]
+
 // --- Elastic Search configuration --- //
-config_vm_elastic_search_image_project   = "open-targets-eu-dev"
-config_vm_elastic_search_vcpus           = "6"
-config_vm_elastic_search_mem             = "39936"
 config_vm_elastic_search_image           = "mbdevplatform-230214-031922-es"
-config_vm_elastic_search_version         = "7.10.2"
-config_vm_elastic_search_boot_disk_size  = "500GB"
-config_vm_elasticsearch_flag_preemptible = true
+
 // --- Clickhouse configuration --- //
-config_vm_clickhouse_vcpus            = "4"
-config_vm_clickhouse_mem              = "26624"
 config_vm_clickhouse_image            = "mbdevplatform-230214-031922-ch"
-config_vm_clickhouse_image_project    = "open-targets-eu-dev"
-config_vm_clickhouse_boot_disk_size   = "250GB"
-config_vm_clickhouse_flag_preemptible = true
+
 // --- API configuration --- //
 config_vm_platform_api_image_version = "dev23.02.7"
-config_vm_api_vcpus                  = "2"
-config_vm_api_mem                    = "7680"
-config_vm_api_image                  = "cos-stable"
-config_vm_api_image_project          = "cos-cloud"
-config_vm_api_boot_disk_size         = "10GB"
-config_vm_api_flag_preemptible       = true
 config_vm_version_major              = "dev23"
 config_vm_version_minor              = "02"
 config_vm_version_patch              = "6"
 config_vm_data_year                  = "23"
 config_vm_data_month                 = "02"
 config_vm_data_iteration             = "0"
-// --- DNS --- //
-config_dns_project_id             = "open-targets-eu-dev"
-config_dns_subdomain_prefix       = "dev"
-config_dns_managed_zone_name      = "opentargets-xyz"
-config_dns_managed_zone_dns_name  = "opentargets.xyz."
-config_dns_platform_api_subdomain = "api"
+
 // --- Web App configuration --- //
-config_webapp_repo_name = "opentargets/ot-ui-apps"
-config_webapp_release   = "v0.3.3"
-config_webapp_deployment_context_map = {
-  DEVOPS_CONTEXT_PLATFORM_APP_CONFIG_URL_API      = "'https://api.platform.dev.opentargets.xyz/api/v4/graphql'"
-  DEVOPS_CONTEXT_PLATFORM_APP_CONFIG_URL_API_BETA = "'https://api.platform.dev.opentargets.xyz/api/v4/graphql'"
-  DEVOPS_CONTEXT_PLATFORM_APP_CONFIG_EFO_URL      = "'/data/ontology/efo_json/diseases_efo.jsonl'"
-}
-// Robots.txt profile --- //
-config_webapp_robots_profile = "default"
-// Web Application Customisation Profile --- //
-// config_webapp_custom_profile = "default.js"
-// Data Context --- //
+config_webapp_release   = "v0.3.4"
+// Data Context
 config_webapp_bucket_name_data_assets = "open-targets-pre-data-releases"
 config_webapp_data_context_release    = "23.02"
-// Sitemaps generation --- //
-config_webapp_sitemaps_repo_name        = "opentargets/ot-sitemap-cli"
-config_webapp_sitemaps_release          = "1.1.0"
-config_webapp_sitemaps_bigquery_table   = "platform_dev"
-config_webapp_sitemaps_bigquery_project = "open-targets-eu-dev"
-// Web App Web Servers configuration --- //
-config_webapp_webserver_docker_image_version = "1.21.3"
-config_vm_webserver_flag_preemptible         = true
-// --- GLB Configuration --- //
-config_glb_webapp_enable_cdn = false
-// --- Security Configuration --- //
-// Allow Access only from Specified CIDR
-// config_security_restrict_source_ips = []
-// Enable / Disable network security policies application
-// config_security_api_enable    = true
-// config_security_webapp_enable = true
-// --- Development Mode --- //
-config_set_dev_mode_on = true
-//config_enable_inspection                    = true

--- a/variables.tf
+++ b/variables.tf
@@ -297,12 +297,6 @@ variable "config_security_webapp_enable" {
   default     = false
 }
 
-variable "config_security_restrict_source_ips" {
-  description = "List of CIDRs that are the only ones allowed to access the internet facing services, default '[]'"
-  type        = list(any)
-  default     = []
-}
-
 variable "config_security_restrict_source_ips_cidrs_file" {
   description = "Text file within the 'profiles' folder that contains the list of CIDRs allowed to access the platform"
   type = string

--- a/variables.tf
+++ b/variables.tf
@@ -299,8 +299,8 @@ variable "config_security_webapp_enable" {
 
 variable "config_security_restrict_source_ips_cidrs_file" {
   description = "Text file within the 'profiles' folder that contains the list of CIDRs allowed to access the platform"
-  type = string
-  default = "netsec_cidr.default"
+  type        = string
+  default     = "netsec_cidr.default"
 }
 // --- Development --- //
 variable "config_set_dev_mode_on" {


### PR DESCRIPTION
This PR implements a layered context for deployment definitions that (should be) is backward compatible with the previous deployment context definitions.
It implements opentargets/issues#2622