### PR TITLE
Update Autoscaling policy for Clickhouse

### DIFF
--- a/modules/clickhouse/main.tf
+++ b/modules/clickhouse/main.tf
@@ -161,7 +161,7 @@ resource "google_compute_region_instance_group_manager" "regmig_clickhouse" {
 
   auto_healing_policies {
     health_check      = google_compute_health_check.clickhouse_healthcheck.id
-    initial_delay_sec = 120
+    initial_delay_sec = 20
   }
 
   update_policy {
@@ -170,7 +170,7 @@ resource "google_compute_region_instance_group_manager" "regmig_clickhouse" {
     minimal_action               = "REPLACE"
     max_surge_fixed              = length(data.google_compute_zones.available.names)
     max_unavailable_fixed        = 0
-    min_ready_sec                = 30
+    min_ready_sec                = 20
   }
   instance_lifecycle_policy {
     force_update_on_repair = "YES"
@@ -187,9 +187,9 @@ resource "google_compute_region_autoscaler" "autoscaler_clickhouse" {
   autoscaling_policy {
     max_replicas    = local.compute_zones_n_total * 2
     min_replicas    = 1
-    cooldown_period = 60
+    cooldown_period = 30
     cpu_utilization {
-      target = 0.45
+      target = 0.65
     }
   }
 }


### PR DESCRIPTION
As discussed, I used the same values as in https://github.com/opentargets/terraform-google-opentargets-platform/pull/37. Looking at a spot vm logs, it looks like it takes about 14 seconds for the instance to get ready. Is there any better way to check this?

This closes [#3246](https://github.com/opentargets/issues/issues/3246).