### PR TITLE
Update Autoscaling policy for API

### DIFF
--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -165,7 +165,7 @@ resource "google_compute_region_instance_group_manager" "regmig_otpapi" {
 
   auto_healing_policies {
     health_check      = google_compute_health_check.otpapi_healthcheck.id
-    initial_delay_sec = 30
+    initial_delay_sec = 20
   }
 
   update_policy {
@@ -174,7 +174,7 @@ resource "google_compute_region_instance_group_manager" "regmig_otpapi" {
     minimal_action               = "REPLACE"
     max_surge_fixed              = length(data.google_compute_zones.available[count.index].names)
     max_unavailable_fixed        = length(data.google_compute_zones.available[count.index].names)
-    min_ready_sec                = 30
+    min_ready_sec                = 20
   }
 
   instance_lifecycle_policy {
@@ -193,12 +193,12 @@ resource "google_compute_region_autoscaler" "autoscaler_otpapi" {
   autoscaling_policy {
     max_replicas    = length(data.google_compute_zones.available[count.index].names) * 2
     min_replicas    = 1
-    cooldown_period = 60
+    cooldown_period = 30
     //    load_balancing_utilization {
     //      target = 0.6
     //    }
     cpu_utilization {
-      target = 0.40
+      target = 0.65
     }
   }
 }


### PR DESCRIPTION
Just like https://github.com/opentargets/terraform-google-opentargets-platform/pull/38. We should keep an eye on this one, as I'm not sure if it takes longer than 20 seconds to start up. Logs are a bit sketchy.

This closes opentargets/issues#3247.