### PR TITLE
Update Autoscaling policy for Web Server

### DIFF
--- a/modules/webapp/webservers-compute.tf
+++ b/modules/webapp/webservers-compute.tf
@@ -141,7 +141,7 @@ resource "google_compute_region_instance_group_manager" "regmig_webserver" {
 
   auto_healing_policies {
     health_check      = google_compute_health_check.webserver_healthcheck.id
-    initial_delay_sec = 30
+    initial_delay_sec = 20
   }
 
   update_policy {
@@ -165,7 +165,7 @@ resource "google_compute_region_autoscaler" "autoscaler_webserver" {
   autoscaling_policy {
     max_replicas    = length(data.google_compute_zones.available[count.index].names) * 2
     min_replicas    = 1
-    cooldown_period = 60
+    cooldown_period = 30
     load_balancing_utilization {
       target = 0.5
     }


### PR DESCRIPTION
Just like https://github.com/opentargets/terraform-google-opentargets-platform/pull/38.

On this one, we could lower the initial delay even more, as nginx is fast to start up.

This closes https://github.com/opentargets/issues/issues/3248.