### PR TITLE
Bump web to 0.7.11

### DIFF
--- a/profiles/deployment_context.2403
+++ b/profiles/deployment_context.2403
@@ -16,7 +16,7 @@ config_vm_data_iteration             = "0"
 // --- OpenAI API configuration --- //
 config_openai_api_docker_image_version = "0.0.10"
 // --- Web App configuration --- //
-config_webapp_release = "v0.7.8"
+config_webapp_release = "v0.7.11"
 // Web App Data Context
 config_webapp_bucket_name_data_assets = "open-targets-pre-data-releases"
 config_webapp_data_context_release    = "24.03"

--- a/profiles/deployment_context.dev-platform
+++ b/profiles/deployment_context.dev-platform
@@ -32,7 +32,7 @@ config_vm_api_mem = 30720
 config_openai_api_docker_image_version = "0.0.10"
 
 // --- Web App configuration --- //
-config_webapp_release = "v0.7.8"
+config_webapp_release = "v0.7.11"
 // Data Context
 config_webapp_data_context_release    = "24.03"
 
@@ -49,5 +49,3 @@ config_security_webapp_enable = false
 //config_vm_elasticsearch_flag_preemptible = false
 //config_vm_webserver_flag_preemptible     = false
 //config_openai_api_flag_preemptible       = false
-
-

--- a/profiles/deployment_context.dev-ppp
+++ b/profiles/deployment_context.dev-ppp
@@ -31,7 +31,7 @@ config_dns_subdomain_prefix       = "dev"
 config_dns_platform_api_subdomain = "api"
 
 // --- Web App configuration --- //
-config_webapp_release = "v0.7.8"
+config_webapp_release = "v0.7.11"
 // Data Context
 config_webapp_data_context_release = "partners/24.03"
 config_webapp_deployment_context_map = {

--- a/profiles/deployment_context.ppp-2403
+++ b/profiles/deployment_context.ppp-2403
@@ -33,7 +33,7 @@ config_dns_managed_zone_name      = "opentargets-org"
 config_dns_managed_zone_dns_name  = "opentargets.org."
 
 // --- Web App configuration --- //
-config_webapp_release = "v0.7.8"
+config_webapp_release = "v0.7.11"
 // Data Context
 config_webapp_data_context_release    = "partners/24.03"
 config_webapp_deployment_context_map = {


### PR DESCRIPTION
This PR bumps web version to [0.7.11](https://github.com/opentargets/ot-ui-apps/releases/tag/v0.7.11) in all the profiles.