### PR TITLE
configurable jvm memory for the api

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -160,6 +160,8 @@ module "backend_api" {
   api_d_month                   = var.config_vm_data_month
   api_d_iteration               = var.config_vm_data_iteration
   api_ignore_cache              = var.config_vm_api_ignore_cache
+  jvm_xms                       = var.config_api_jvm_xms
+  jvm_xmx                       = var.config_api_jvm_xmx
   vm_flag_preemptible           = var.config_vm_api_flag_preemptible
   backend_connection_map = zipmap(
     var.config_deployment_regions,

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -27,7 +27,9 @@ resource "random_string" "random" {
     vm_api_data_year              = var.api_d_year,
     vm_api_data_month             = var.api_d_month,
     vm_api_data_iter              = var.api_d_iteration,
-    vm_api_ignore_cache           = var.api_ignore_cache
+    vm_api_ignore_cache           = var.api_ignore_cache,
+    jvm_xms                       = var.jvm_xms,
+    jvm_xmx                       = var.jvm_xmx
   }
 }
 
@@ -112,6 +114,8 @@ resource "google_compute_instance_template" "otpapi_template" {
         API_DATA_MONTH       = var.api_d_month,
         API_DATA_ITER        = var.api_d_iteration,
         API_IGNORE_CACHE     = var.api_ignore_cache
+        JVM_XMS              = var.jvm_xms,
+        JVM_XMX              = var.jvm_xmx
       }
     )
     google-logging-enabled = true

--- a/modules/api/scripts/instance_startup.sh
+++ b/modules/api/scripts/instance_startup.sh
@@ -13,4 +13,6 @@ docker run -d \
   -e META_DATA_MONTH='${API_DATA_MONTH}' \
   -e META_DATA_ITERATION='${API_DATA_ITER}' \
   -e PLATFORM_API_IGNORE_CACHE='${API_IGNORE_CACHE}' \
+  -e JVM_XMS='${JVM_XMS}' \
+  -e JVM_XMX='${JVM_XMX}' \
   quay.io/opentargets/platform-api:${PLATFORM_API_VERSION}

--- a/modules/api/variables.tf
+++ b/modules/api/variables.tf
@@ -78,6 +78,18 @@ variable "vm_api_mem" {
   default     = "7680"
 }
 
+variable "jvm_xms" {
+  description = "JVM initial heap size, default '2g'"
+  type        = string
+  default     = "2g"
+}
+
+variable "jvm_xmx" {
+  description = "JVM maximum heap size, default '7g'"
+  type        = string
+  default     = "7g"
+}
+
 variable "vm_api_image" {
   description = "VM image to use for API nodes, default 'cos-stable'"
   type        = string

--- a/profiles/deployment_context.dev-platform
+++ b/profiles/deployment_context.dev-platform
@@ -25,6 +25,8 @@ config_vm_data_year                  = "25"
 config_vm_data_month                 = "03"
 config_vm_data_iteration             = "0"
 config_vm_api_ignore_cache           = true
+config_api_jvm_xms                   = "2g"
+config_api_jvm_xmx                   = "7g"
 # config_vm_api_vcpus                  = 8
 # config_vm_api_mem                    = 30720
 

--- a/variables.tf
+++ b/variables.tf
@@ -434,6 +434,16 @@ variable "config_vm_api_ignore_cache" {
   type        = bool
   default     = false
 }
+variable "config_api_jvm_xms" {
+  description = "Xms (initial memory allocation pool) parameter for the API JVM"
+  type        = string
+  default     = "2g"
+}
+variable "config_api_jvm_xmx" {
+  description = "Xmx (maximum memory allocation pool) parameter for the API JVM"
+  type        = string
+  default     = "7g"
+}
 
 // --- OpenAI API --- //
 variable "config_openai_api_docker_image_version" {


### PR DESCRIPTION
added necessary config to be able to set jvm xms and xmx for the api.