### PR TITLE
fix webapp image name

### DIFF
--- a/modules/webapp/scripts/webserver_vm_startup_script.sh
+++ b/modules/webapp/scripts/webserver_vm_startup_script.sh
@@ -4,4 +4,4 @@ docker run -d \
     --log-driver=gcplogs \
     -p 8080:8080 \
     ${env_vars} \
-    ghcr.io/opentargets/ot-ui-apps/ot-ui-apps:${webapp_image_version}
+    ghcr.io/opentargets/ot-ui-apps:${webapp_image_version}


### PR DESCRIPTION
Do not merge until https://github.com/opentargets/ot-ui-apps/pull/797 is merged and a new image is created, so we have one to build the webapp machines.